### PR TITLE
fix: responsive layout improvements for mobile displays

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -42,125 +42,157 @@ export default function Header() {
     document.documentElement.setAttribute('data-theme', newTheme)
   }
 
-  const closeDropdown = () => {
-    if (document.activeElement instanceof HTMLElement) {
-      document.activeElement.blur()
+  const closeDrawer = () => {
+    const drawerToggle = document.getElementById(
+      'header-drawer',
+    ) as HTMLInputElement | null
+    if (drawerToggle) {
+      drawerToggle.checked = false
     }
   }
 
   return (
-    <header className="navbar bg-base-100 shadow-lg sticky top-0 z-50 border-b border-base-300">
-      <div className="navbar-start">
-        <Link to="/" className="btn btn-ghost text-xl gap-2">
-          <img
-            src="/pcs_shield.png"
-            alt="PCS Logo"
-            className="w-6 h-6 object-contain"
+    <>
+      <div className="drawer drawer-end z-50">
+        <input
+          id="header-drawer"
+          type="checkbox"
+          className="drawer-toggle"
+          aria-label="Toggle navigation menu"
+        />
+        <div className="drawer-content">
+          {/* Navbar */}
+          <header className="navbar bg-base-100 shadow-lg sticky top-0 z-40 border-b border-base-300">
+            <div className="navbar-start">
+              <Link to="/" className="btn btn-ghost text-base sm:text-xl gap-2">
+                <img
+                  src="/pcs_shield.png"
+                  alt="PCS Logo"
+                  className="w-5 h-5 sm:w-6 sm:h-6 object-contain"
+                />
+                <span className="hidden sm:inline">Squash Score Keeper</span>
+                <span className="sm:hidden">Squash</span>
+              </Link>
+            </div>
+            <div className="navbar-center hidden lg:flex">
+              <div className="badge badge-ghost badge-md lg:badge-lg">
+                PAR-15 Doubles Scoring
+              </div>
+            </div>
+            <div className="navbar-end gap-1 sm:gap-2">
+              <LoginButton />
+              <button
+                onClick={toggleTheme}
+                className="btn btn-ghost btn-circle btn-sm sm:btn-md"
+                aria-label="Toggle theme"
+              >
+                {theme === 'pcsquash' ? (
+                  <Moon className="w-4 h-4 sm:w-5 sm:h-5" />
+                ) : (
+                  <Sun className="w-4 h-4 sm:w-5 sm:h-5" />
+                )}
+              </button>
+              {/* Hamburger menu button - visible on all screens */}
+              <label
+                htmlFor="header-drawer"
+                className="btn btn-ghost btn-circle btn-sm sm:btn-md drawer-button"
+                aria-label="Open menu"
+              >
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  className="h-4 w-4 sm:h-5 sm:w-5"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth="2"
+                    d="M4 6h16M4 12h16M4 18h16"
+                  />
+                </svg>
+              </label>
+            </div>
+          </header>
+        </div>
+        {/* Drawer sidebar */}
+        <div className="drawer-side">
+          <label
+            htmlFor="header-drawer"
+            aria-label="Close menu"
+            className="drawer-overlay"
           />
-          <span className="hidden sm:inline">Squash Score Keeper</span>
-          <span className="sm:hidden">Squash</span>
-        </Link>
-      </div>
-      <div className="navbar-center hidden md:flex">
-        <div className="badge badge-ghost badge-lg">PAR-15 Doubles Scoring</div>
-      </div>
-      <div className="navbar-end gap-2">
-        <LoginButton />
-        <button
-          onClick={toggleTheme}
-          className="btn btn-ghost btn-circle"
-          aria-label="Toggle theme"
-        >
-          {theme === 'pcsquash' ? (
-            <Moon className="w-5 h-5" />
-          ) : (
-            <Sun className="w-5 h-5" />
-          )}
-        </button>
-        <div className="dropdown dropdown-end">
-          <div tabIndex={0} role="button" className="btn btn-ghost btn-circle">
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              className="h-5 w-5"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth="2"
-                d="M4 6h16M4 12h16M4 18h7"
-              />
-            </svg>
-          </div>
-          <ul
-            tabIndex={0}
-            className="menu menu-sm dropdown-content bg-base-100 rounded-box z-[1] mt-3 w-52 p-2 shadow-xl border border-base-300"
-          >
+          <ul className="menu bg-base-100 min-h-full w-72 sm:w-80 p-4 gap-1">
+            {/* Drawer header */}
+            <li className="menu-title">
+              <span className="text-lg font-bold">Navigation</span>
+            </li>
             <li>
-              <Link to="/" onClick={closeDropdown}>
+              <Link to="/" onClick={closeDrawer}>
                 Home
               </Link>
             </li>
             <li>
-              <Link to="/matches" onClick={closeDropdown}>
+              <Link to="/matches" onClick={closeDrawer}>
                 All Matches
               </Link>
             </li>
             {can('user.view') && (
               <>
+                <li className="menu-title mt-4">
+                  <span>Management</span>
+                </li>
                 <li>
-                  <Link to="/players" onClick={closeDropdown}>
+                  <Link to="/players" onClick={closeDrawer}>
                     Player Management
                   </Link>
                 </li>
                 <li>
-                  <Link to="/users" onClick={closeDropdown}>
+                  <Link to="/users" onClick={closeDrawer}>
                     User Management
                   </Link>
                 </li>
               </>
             )}
+            <li className="menu-title mt-4">
+              <span>Referee Tools</span>
+            </li>
             <li>
-              Referee Tools
-              <ul>
-                <li>
-                  <button
-                    onClick={() => {
-                      updateModalState({
-                        ...modalState,
-                        letStrokeModal: { isOpen: true },
-                      })
-                      closeDropdown()
-                    }}
-                  >
-                    Let/Stroke Helper
-                  </button>
-                </li>
-                <li>
-                  <button
-                    onClick={() => {
-                      updateModalState({
-                        ...modalState,
-                        timersModal: { isOpen: true },
-                      })
-                      closeDropdown()
-                    }}
-                  >
-                    Timers & Conduct
-                  </button>
-                </li>
-                <li>
-                  <a
-                    href="https://ussquash.org/wp-content/uploads/2024/11/2024-Hardball-Squash-Doubles-Rules.pdf"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    Hardball Rules (PDF)
-                  </a>
-                </li>
-              </ul>
+              <button
+                onClick={() => {
+                  updateModalState({
+                    ...modalState,
+                    letStrokeModal: { isOpen: true },
+                  })
+                  closeDrawer()
+                }}
+              >
+                Let/Stroke Helper
+              </button>
+            </li>
+            <li>
+              <button
+                onClick={() => {
+                  updateModalState({
+                    ...modalState,
+                    timersModal: { isOpen: true },
+                  })
+                  closeDrawer()
+                }}
+              >
+                Timers & Conduct
+              </button>
+            </li>
+            <li>
+              <a
+                href="https://ussquash.org/wp-content/uploads/2024/11/2024-Hardball-Squash-Doubles-Rules.pdf"
+                target="_blank"
+                rel="noopener noreferrer"
+                onClick={closeDrawer}
+              >
+                Hardball Rules (PDF)
+              </a>
             </li>
           </ul>
         </div>
@@ -183,6 +215,6 @@ export default function Header() {
           })
         }
       />
-    </header>
+    </>
   )
 }

--- a/src/components/game/NextGameSetup.tsx
+++ b/src/components/game/NextGameSetup.tsx
@@ -93,16 +93,23 @@ export const NextGameSetup = ({
 
   return (
     <dialog className="modal modal-open">
-      <div className="modal-box max-w-2xl">
-        <h3 className="font-bold text-lg mb-4">
+      <div className="modal-box max-w-2xl p-4 sm:p-6">
+        <h3 className="font-bold text-base sm:text-lg mb-3 sm:mb-4">
           {isFirstGame ? 'Setup First Game' : 'Setup Next Game'}
         </h3>
 
         {/* Serving Team Selection */}
-        <h4 className="font-semibold mb-3">Who serves first?</h4>
-        <div className="flex gap-3 justify-center">
-          <label className="label cursor-pointer flex-col gap-2 p-4 border-2 border-base-300 rounded-lg hover:bg-base-300 flex-1">
-            <span className="label-text font-bold">{players.teamA}</span>
+        <h4 className="font-semibold text-sm sm:text-base mb-2 sm:mb-3">
+          Who serves first?
+        </h4>
+        <div className="flex gap-2 sm:gap-3 justify-center">
+          <label className="label cursor-pointer flex-col gap-1 sm:gap-2 p-2 sm:p-4 border-2 border-base-300 rounded-lg hover:bg-base-300 flex-1 min-w-0">
+            <span
+              className="label-text font-bold text-xs sm:text-sm line-clamp-2 leading-tight text-center"
+              title={players.teamA}
+            >
+              {players.teamA}
+            </span>
             {!isFirstGame && lastWinner === 'A' && (
               <span className="text-xs text-success">(Last Winner)</span>
             )}
@@ -116,8 +123,13 @@ export const NextGameSetup = ({
               }
             />
           </label>
-          <label className="label cursor-pointer flex-col gap-2 p-4 border-2 border-base-300 rounded-lg hover:bg-base-300 flex-1">
-            <span className="label-text font-bold">{players.teamB}</span>
+          <label className="label cursor-pointer flex-col gap-1 sm:gap-2 p-2 sm:p-4 border-2 border-base-300 rounded-lg hover:bg-base-300 flex-1 min-w-0">
+            <span
+              className="label-text font-bold text-xs sm:text-sm line-clamp-2 leading-tight text-center"
+              title={players.teamB}
+            >
+              {players.teamB}
+            </span>
             {!isFirstGame && lastWinner === 'B' && (
               <span className="text-xs text-success">(Last Winner)</span>
             )}
@@ -140,19 +152,29 @@ export const NextGameSetup = ({
         )}
 
         {/* First Server Designation */}
-        <div className="card bg-base-200 p-4 mb-4">
-          <h4 className="font-semibold mb-3">First Server Designation</h4>
-          <div className="text-xs text-base-content/70 mb-3">
+        <div className="card bg-base-200 p-3 sm:p-4 mb-3 sm:mb-4">
+          <h4 className="font-semibold text-sm sm:text-base mb-2 sm:mb-3">
+            First Server Designation
+          </h4>
+          <div className="text-[10px] sm:text-xs text-base-content/70 mb-2 sm:mb-3">
             Who serves first on hand-in for each team?
           </div>
 
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-3 sm:gap-4">
             {/* Team A First Server */}
             <div className="space-y-2">
-              <div className="font-semibold text-sm">{players.teamA}</div>
+              <div
+                className="font-semibold text-xs sm:text-sm line-clamp-1"
+                title={players.teamA}
+              >
+                {players.teamA}
+              </div>
               <div className="flex gap-2">
-                <label className="label cursor-pointer flex-1 flex-col gap-2 p-3 border border-base-300 rounded-lg hover:bg-base-300">
-                  <span className="label-text font-semibold">
+                <label className="label cursor-pointer flex-1 flex-col gap-1 sm:gap-2 p-2 sm:p-3 border border-base-300 rounded-lg hover:bg-base-300 min-w-0">
+                  <span
+                    className="label-text font-semibold text-[10px] sm:text-xs line-clamp-2 leading-tight text-center"
+                    title={players.A1.fullName}
+                  >
                     {players.A1.fullName}
                   </span>
                   <input
@@ -165,8 +187,11 @@ export const NextGameSetup = ({
                     }
                   />
                 </label>
-                <label className="label cursor-pointer flex-1 flex-col gap-2 p-3 border border-base-300 rounded-lg hover:bg-base-300">
-                  <span className="label-text font-semibold">
+                <label className="label cursor-pointer flex-1 flex-col gap-1 sm:gap-2 p-2 sm:p-3 border border-base-300 rounded-lg hover:bg-base-300 min-w-0">
+                  <span
+                    className="label-text font-semibold text-[10px] sm:text-xs line-clamp-2 leading-tight text-center"
+                    title={players.A2.fullName}
+                  >
                     {players.A2.fullName}
                   </span>
                   <input
@@ -184,10 +209,18 @@ export const NextGameSetup = ({
 
             {/* Team B First Server */}
             <div className="space-y-2">
-              <div className="font-semibold text-sm">{players.teamB}</div>
+              <div
+                className="font-semibold text-xs sm:text-sm line-clamp-1"
+                title={players.teamB}
+              >
+                {players.teamB}
+              </div>
               <div className="flex gap-2">
-                <label className="label cursor-pointer flex-1 flex-col gap-2 p-3 border border-base-300 rounded-lg hover:bg-base-300">
-                  <span className="label-text font-semibold">
+                <label className="label cursor-pointer flex-1 flex-col gap-1 sm:gap-2 p-2 sm:p-3 border border-base-300 rounded-lg hover:bg-base-300 min-w-0">
+                  <span
+                    className="label-text font-semibold text-[10px] sm:text-xs line-clamp-2 leading-tight text-center"
+                    title={players.B1.fullName}
+                  >
                     {players.B1.fullName}
                   </span>
                   <input
@@ -200,8 +233,11 @@ export const NextGameSetup = ({
                     }
                   />
                 </label>
-                <label className="label cursor-pointer flex-1 flex-col gap-2 p-3 border border-base-300 rounded-lg hover:bg-base-300">
-                  <span className="label-text font-semibold">
+                <label className="label cursor-pointer flex-1 flex-col gap-1 sm:gap-2 p-2 sm:p-3 border border-base-300 rounded-lg hover:bg-base-300 min-w-0">
+                  <span
+                    className="label-text font-semibold text-[10px] sm:text-xs line-clamp-2 leading-tight text-center"
+                    title={players.B2.fullName}
+                  >
                     {players.B2.fullName}
                   </span>
                   <input
@@ -220,13 +256,17 @@ export const NextGameSetup = ({
         </div>
 
         {/* Actions */}
-        <div className="modal-action">
-          <button type="button" className="btn btn-ghost" onClick={onCancel}>
+        <div className="modal-action gap-2">
+          <button
+            type="button"
+            className="btn btn-ghost btn-sm sm:btn-md"
+            onClick={onCancel}
+          >
             Cancel
           </button>
           <button
             type="button"
-            className="btn btn-primary"
+            className="btn btn-primary btn-sm sm:btn-md"
             onClick={handleStartGame}
           >
             Start Game

--- a/src/components/game/RallyButtons.tsx
+++ b/src/components/game/RallyButtons.tsx
@@ -1,7 +1,7 @@
 import { useSelector } from '@xstate/react'
 import { useQuery } from '@livestore/react'
 import { gameById$, matchById$ } from '../../livestore/squash-queries'
-import { getTeamNames } from './match-utils'
+import { getTeamNames, getTeamNamesAbbreviated } from './match-utils'
 import type { ActorRefFrom } from 'xstate'
 
 import type { squashGameMachine } from '../../machines/squashGameMachine'
@@ -24,6 +24,7 @@ export const RallyButtons = ({ actorRef, gameId }: RallyButtonsProps) => {
   // Query match for player names
   const match = useQuery(matchById$(game.matchId))
   const teamNames = getTeamNames(match)
+  const teamNamesAbbr = getTeamNamesAbbreviated(match)
 
   const isDisabled = isGameOver || isAwaitingConfirmation
 
@@ -32,25 +33,37 @@ export const RallyButtons = ({ actorRef, gameId }: RallyButtonsProps) => {
   }
 
   return (
-    <div className="flex flex-col sm:flex-row gap-3 mb-4">
+    <div className="flex flex-col sm:flex-row gap-2 sm:gap-3 mb-3 sm:mb-4">
       <button
-        className="btn btn-primary flex-1 btn-lg shadow-lg hover:shadow-xl transition-all"
+        className="btn btn-primary flex-1 btn-md sm:btn-lg shadow-lg hover:shadow-xl transition-all min-h-[4rem] sm:min-h-[5rem]"
         onClick={() => onRallyWon('A')}
         disabled={isDisabled}
       >
-        <div className="flex flex-col items-center gap-1">
-          <span className="font-bold">{teamNames.teamA}</span>
-          <span className="text-xs opacity-80">Won Rally</span>
+        <div className="flex flex-col items-center gap-0.5 sm:gap-1 w-full px-2">
+          <span
+            className="font-bold text-xs sm:text-sm lg:text-base line-clamp-2 leading-tight text-center max-w-full"
+            title={teamNames.teamA}
+          >
+            <span className="lg:hidden">{teamNamesAbbr.teamA}</span>
+            <span className="hidden lg:inline">{teamNames.teamA}</span>
+          </span>
+          <span className="text-[10px] sm:text-xs opacity-80">Won Rally</span>
         </div>
       </button>
       <button
-        className="btn btn-primary flex-1 btn-lg shadow-lg hover:shadow-xl transition-all"
+        className="btn btn-primary flex-1 btn-md sm:btn-lg shadow-lg hover:shadow-xl transition-all min-h-[4rem] sm:min-h-[5rem]"
         onClick={() => onRallyWon('B')}
         disabled={isDisabled}
       >
-        <div className="flex flex-col items-center gap-1">
-          <span className="font-bold">{teamNames.teamB}</span>
-          <span className="text-xs opacity-80">Won Rally</span>
+        <div className="flex flex-col items-center gap-0.5 sm:gap-1 w-full px-2">
+          <span
+            className="font-bold text-xs sm:text-sm lg:text-base line-clamp-2 leading-tight text-center max-w-full"
+            title={teamNames.teamB}
+          >
+            <span className="lg:hidden">{teamNamesAbbr.teamB}</span>
+            <span className="hidden lg:inline">{teamNames.teamB}</span>
+          </span>
+          <span className="text-[10px] sm:text-xs opacity-80">Won Rally</span>
         </div>
       </button>
     </div>

--- a/src/components/game/ScoreCell.tsx
+++ b/src/components/game/ScoreCell.tsx
@@ -21,7 +21,7 @@ export const ScoreCell = memo(
       <td
         rowSpan={rowSpan}
         onClick={onClick}
-        className={`border border-base-300 p-0.5 sm:p-1 text-center text-xs sm:text-sm min-w-[28px] sm:min-w-[32px] ${bgColor} ${isClickable ? 'cursor-pointer hover:bg-primary/40' : ''}`}
+        className={`border border-base-300 p-0.5 sm:p-1 text-center text-[10px] sm:text-xs min-w-[24px] sm:min-w-[28px] md:min-w-[32px] ${bgColor} ${isClickable ? 'cursor-pointer hover:bg-primary/40' : ''}`}
         title={isClickable ? 'Click to toggle R/L' : ''}
       >
         {cell || ''}

--- a/src/components/game/ScoreHeader.tsx
+++ b/src/components/game/ScoreHeader.tsx
@@ -4,7 +4,11 @@ import {
   gamesByMatch$,
   matchById$,
 } from '../../livestore/squash-queries'
-import { getTeamNames } from './match-utils'
+import {
+  getTeamNames,
+  getTeamNamesAbbreviated,
+  getTeamNamesCompact,
+} from './match-utils'
 
 type TeamKey = 'teamA' | 'teamB'
 
@@ -30,6 +34,8 @@ export const ScoreHeader = ({
 
   // Build team names from match data
   const teamNames = getTeamNames(match)
+  const teamNamesAbbr = getTeamNamesAbbreviated(match)
+  const teamNamesCompact = getTeamNamesCompact(match)
 
   // Compute derived values from games
   const currentGameNumber =
@@ -52,23 +58,30 @@ export const ScoreHeader = ({
 
   return (
     <div className="card bg-base-100 shadow-xl mb-3 border border-base-300">
-      <div className="card-body p-3 sm:p-4">
-        <div className="flex justify-between items-center gap-4">
-          <div className="flex-1 flex items-center gap-3">
+      <div className="card-body p-2 sm:p-3 md:p-4">
+        <div className="flex justify-between items-center gap-1.5 sm:gap-2 md:gap-4">
+          <div className="flex items-center gap-1.5 sm:gap-2 md:gap-3 flex-1 min-w-0">
             <div
-              className={`w-16 h-16 sm:w-20 sm:h-20 rounded-full flex items-center justify-center text-2xl sm:text-4xl font-bold transition-all bg-base-200 text-base-content`}
+              className={`w-12 h-12 sm:w-16 sm:h-16 md:w-20 md:h-20 rounded-full flex items-center justify-center text-xl sm:text-2xl md:text-4xl font-bold transition-all bg-base-200 text-base-content flex-shrink-0`}
             >
               {topScore}
             </div>
             <div className="flex-1 min-w-0">
-              <h1 className="text-sm sm:text-lg font-bold truncate">
-                {teamNames[topTeam]}
+              <h1
+                className="text-[10px] sm:text-xs md:text-sm lg:text-lg font-bold line-clamp-2 leading-tight"
+                title={teamNames[topTeam]}
+              >
+                <span className="sm:hidden">{teamNamesCompact[topTeam]}</span>
+                <span className="hidden sm:inline lg:hidden">
+                  {teamNamesAbbr[topTeam]}
+                </span>
+                <span className="hidden lg:inline">{teamNames[topTeam]}</span>
               </h1>
-              <div className="flex gap-1 mt-1">
+              <div className="flex gap-1 mt-0.5 sm:mt-1">
                 {Array.from({ length: topTeamGamesWon }).map((_, i) => (
                   <div
                     key={i}
-                    className="w-2 h-2 rounded-full bg-success"
+                    className="w-1.5 h-1.5 sm:w-2 sm:h-2 rounded-full bg-success"
                     title={`Game ${i + 1} won`}
                   />
                 ))}
@@ -76,27 +89,38 @@ export const ScoreHeader = ({
             </div>
           </div>
 
-          <div className="text-center px-2 flex-shrink-0">
-            <div className="badge badge-primary badge-lg">
+          <div className="text-center px-1 sm:px-2 flex-shrink-0">
+            <div className="badge badge-primary badge-sm sm:badge-md md:badge-lg whitespace-nowrap">
               Game {currentGameNumber}
             </div>
           </div>
 
-          <div className="flex-1 flex items-center gap-3 flex-row-reverse">
+          <div className="flex items-center gap-1.5 sm:gap-2 md:gap-3 flex-row-reverse flex-1 min-w-0">
             <div
-              className={`w-16 h-16 sm:w-20 sm:h-20 rounded-full flex items-center justify-center text-2xl sm:text-4xl font-bold transition-all bg-base-200 text-base-content`}
+              className={`w-12 h-12 sm:w-16 sm:h-16 md:w-20 md:h-20 rounded-full flex items-center justify-center text-xl sm:text-2xl md:text-4xl font-bold transition-all bg-base-200 text-base-content flex-shrink-0`}
             >
               {bottomScore}
             </div>
             <div className="flex-1 min-w-0 text-right">
-              <h1 className="text-sm sm:text-lg font-bold truncate">
-                {teamNames[bottomTeam]}
+              <h1
+                className="text-[10px] sm:text-xs md:text-sm lg:text-lg font-bold line-clamp-2 leading-tight"
+                title={teamNames[bottomTeam]}
+              >
+                <span className="sm:hidden">
+                  {teamNamesCompact[bottomTeam]}
+                </span>
+                <span className="hidden sm:inline lg:hidden">
+                  {teamNamesAbbr[bottomTeam]}
+                </span>
+                <span className="hidden lg:inline">
+                  {teamNames[bottomTeam]}
+                </span>
               </h1>
-              <div className="flex gap-1 mt-1 justify-end">
+              <div className="flex gap-1 mt-0.5 sm:mt-1 justify-end">
                 {Array.from({ length: bottomTeamGamesWon }).map((_, i) => (
                   <div
                     key={i}
-                    className="w-2 h-2 rounded-full bg-success"
+                    className="w-1.5 h-1.5 sm:w-2 sm:h-2 rounded-full bg-success"
                     title={`Game ${i + 1} won`}
                   />
                 ))}

--- a/src/components/game/ScoreTable.tsx
+++ b/src/components/game/ScoreTable.tsx
@@ -63,19 +63,19 @@ export const ScoreTable = ({
   const teamPairs = groupRowsIntoTeamPairs(rows)
 
   return (
-    <div className="card bg-base-100 shadow-xl mb-4 border border-base-300">
-      <div className="card-body p-2 sm:p-4">
-        <div className="overflow-x-auto -mx-2 sm:mx-0 rounded-lg">
+    <div className="card bg-base-100 shadow-xl mb-3 sm:mb-4 border border-base-300">
+      <div className="card-body p-1.5 sm:p-2 md:p-4">
+        <div className="overflow-x-auto -mx-1.5 sm:-mx-2 md:mx-0 rounded-lg">
           <table className="table table-xs w-full">
             <thead>
               <tr>
-                <th className="border border-base-300 p-1 text-center sticky left-0 bg-base-200 z-10 min-w-[60px] sm:min-w-[80px] font-bold">
-                  <span className="text-[10px] sm:text-xs">Player</span>
+                <th className="border border-base-300 p-0.5 sm:p-1 text-center sticky left-0 bg-base-200 z-10 min-w-[55px] sm:min-w-[75px] md:min-w-[95px] font-bold">
+                  <span className="text-[9px] sm:text-[10px]">Player</span>
                 </th>
                 {Array.from({ length: maxCols }, (_, i) => (
                   <th
                     key={i}
-                    className="border border-base-300 p-1 text-center text-[10px] sm:text-xs min-w-[28px] sm:min-w-[32px] bg-base-200 font-bold"
+                    className="border border-base-300 p-0.5 sm:p-1 text-center text-[9px] sm:text-[10px] min-w-[24px] sm:min-w-[28px] md:min-w-[32px] bg-base-200 font-bold"
                   >
                     {i}
                   </th>

--- a/src/components/game/TeamRows.tsx
+++ b/src/components/game/TeamRows.tsx
@@ -104,12 +104,15 @@ export const TeamRows = memo(
       <>
         {/* First player row */}
         <tr>
-          <td className="border border-base-300 p-1 font-bold sticky left-0 bg-base-200 z-10">
-            <div className="flex flex-col">
-              <span className="text-[10px] sm:text-xs text-primary font-semibold">
+          <td className="border border-base-300 p-0.5 sm:p-1 font-bold sticky left-0 bg-base-200 z-10">
+            <div className="flex flex-col gap-0.5">
+              <span className="text-[9px] sm:text-[10px] text-primary font-semibold">
                 {player1Key}
               </span>
-              <span className="text-xs sm:text-sm truncate max-w-[50px] sm:max-w-[70px]">
+              <span
+                className="text-[10px] sm:text-xs truncate max-w-[50px] sm:max-w-[70px] md:max-w-[90px]"
+                title={playerLabels[player1Key]}
+              >
                 {playerLabels[player1Key]}
               </span>
             </div>
@@ -121,12 +124,15 @@ export const TeamRows = memo(
 
         {/* Second player row */}
         <tr>
-          <td className="border border-base-300 p-1 font-bold sticky left-0 bg-base-200 z-10">
-            <div className="flex flex-col">
-              <span className="text-[10px] sm:text-xs text-primary font-semibold">
+          <td className="border border-base-300 p-0.5 sm:p-1 font-bold sticky left-0 bg-base-200 z-10">
+            <div className="flex flex-col gap-0.5">
+              <span className="text-[9px] sm:text-[10px] text-primary font-semibold">
                 {player2Key}
               </span>
-              <span className="text-xs sm:text-sm truncate max-w-[50px] sm:max-w-[70px]">
+              <span
+                className="text-[10px] sm:text-xs truncate max-w-[50px] sm:max-w-[70px] md:max-w-[90px]"
+                title={playerLabels[player2Key]}
+              >
                 {playerLabels[player2Key]}
               </span>
             </div>

--- a/src/components/game/match-utils.ts
+++ b/src/components/game/match-utils.ts
@@ -1,3 +1,8 @@
+import {
+  formatTeamNameAbbreviated,
+  formatTeamNameFull,
+} from '../../utils/nameUtils'
+
 type MatchData = {
   playerA1FirstName: string
   playerA1LastName: string
@@ -16,10 +21,77 @@ const getPlayerName = (firstName: string, lastName: string): string =>
   lastName || firstName
 
 /**
- * Get formatted team names for display
+ * Get formatted team names for display (full names)
  * Prefers last names, falls back to first names if last name is empty
  */
 export const getTeamNames = (match: MatchData) => ({
   teamA: `${getPlayerName(match.playerA1FirstName, match.playerA1LastName)} & ${getPlayerName(match.playerA2FirstName, match.playerA2LastName)}`,
   teamB: `${getPlayerName(match.playerB1FirstName, match.playerB1LastName)} & ${getPlayerName(match.playerB2FirstName, match.playerB2LastName)}`,
 })
+
+/**
+ * Get abbreviated team names for responsive display (e.g., "J. Gordon & M. Smith")
+ */
+export const getTeamNamesAbbreviated = (match: MatchData) => ({
+  teamA: formatTeamNameAbbreviated(
+    match.playerA1FirstName,
+    match.playerA1LastName,
+    match.playerA2FirstName,
+    match.playerA2LastName,
+  ),
+  teamB: formatTeamNameAbbreviated(
+    match.playerB1FirstName,
+    match.playerB1LastName,
+    match.playerB2FirstName,
+    match.playerB2LastName,
+  ),
+})
+
+/**
+ * Get full team names for display
+ */
+export const getTeamNamesFull = (match: MatchData) => ({
+  teamA: formatTeamNameFull(
+    match.playerA1FirstName,
+    match.playerA1LastName,
+    match.playerA2FirstName,
+    match.playerA2LastName,
+  ),
+  teamB: formatTeamNameFull(
+    match.playerB1FirstName,
+    match.playerB1LastName,
+    match.playerB2FirstName,
+    match.playerB2LastName,
+  ),
+})
+
+/**
+ * Get ultra-compact team names for very small screens (e.g., "biggles & busver")
+ * Truncates last names to 7 characters max
+ */
+export const getTeamNamesCompact = (match: MatchData) => {
+  const truncate = (name: string, maxLen: number = 7) =>
+    name.length > maxLen ? name.substring(0, maxLen) : name
+
+  const player1A = getPlayerName(
+    match.playerA1FirstName,
+    match.playerA1LastName,
+  )
+  const player2A = getPlayerName(
+    match.playerA2FirstName,
+    match.playerA2LastName,
+  )
+  const player1B = getPlayerName(
+    match.playerB1FirstName,
+    match.playerB1LastName,
+  )
+  const player2B = getPlayerName(
+    match.playerB2FirstName,
+    match.playerB2LastName,
+  )
+
+  return {
+    teamA: `${truncate(player1A)} & ${truncate(player2A)}`,
+    teamB: `${truncate(player1B)} & ${truncate(player2B)}`,
+  }
+}

--- a/src/components/modals/DeleteMatchModal.tsx
+++ b/src/components/modals/DeleteMatchModal.tsx
@@ -19,37 +19,52 @@ export const DeleteMatchModal = ({
 
   return (
     <div className="modal modal-open">
-      <div className="modal-box">
-        <div className="flex items-start gap-3 mb-4">
+      <div className="modal-box p-4 sm:p-6">
+        <div className="flex items-start gap-2 sm:gap-3 mb-3 sm:mb-4">
           <div className="flex-shrink-0">
-            <AlertTriangle className="w-6 h-6 text-error" />
+            <AlertTriangle className="w-5 h-5 sm:w-6 sm:h-6 text-error" />
           </div>
-          <div className="flex-1">
-            <h2 className="text-xl font-bold mb-2">Delete Match?</h2>
-            <p className="text-base-content/70 mb-3">
+          <div className="flex-1 min-w-0">
+            <h2 className="text-lg sm:text-xl font-bold mb-2">Delete Match?</h2>
+            <p className="text-sm sm:text-base text-base-content/70 mb-3">
               Are you sure you want to delete this match? This action cannot be
               undone.
             </p>
-            <div className="bg-base-300 p-3 rounded-lg">
-              <div className="text-sm font-medium">{teamAName}</div>
-              <div className="text-xs text-base-content/50">vs</div>
-              <div className="text-sm font-medium">{teamBName}</div>
+            <div className="bg-base-300 p-2 sm:p-3 rounded-lg">
+              <div
+                className="text-xs sm:text-sm font-medium line-clamp-2 leading-tight"
+                title={teamAName}
+              >
+                {teamAName}
+              </div>
+              <div className="text-[10px] sm:text-xs text-base-content/50">
+                vs
+              </div>
+              <div
+                className="text-xs sm:text-sm font-medium line-clamp-2 leading-tight"
+                title={teamBName}
+              >
+                {teamBName}
+              </div>
             </div>
           </div>
           <button
             onClick={onCancel}
-            className="btn btn-ghost btn-circle btn-sm"
+            className="btn btn-ghost btn-circle btn-xs sm:btn-sm flex-shrink-0"
             aria-label="Close modal"
           >
-            <X className="w-5 h-5" />
+            <X className="w-4 h-4 sm:w-5 sm:h-5" />
           </button>
         </div>
 
-        <div className="modal-action">
-          <button onClick={onCancel} className="btn btn-ghost">
+        <div className="modal-action gap-2">
+          <button onClick={onCancel} className="btn btn-ghost btn-sm sm:btn-md">
             Cancel
           </button>
-          <button onClick={onConfirm} className="btn btn-error">
+          <button
+            onClick={onConfirm}
+            className="btn btn-error btn-sm sm:btn-md"
+          >
             Delete Match
           </button>
         </div>

--- a/src/components/modals/LetStrokeModal.tsx
+++ b/src/components/modals/LetStrokeModal.tsx
@@ -11,15 +11,17 @@ export const LetStrokeModal = ({ isOpen, onClose }: LetStrokeModalProps) => {
 
   return (
     <div className="modal modal-open">
-      <div className="modal-box max-w-2xl">
-        <div className="flex justify-between items-center mb-4">
-          <h2 className="text-2xl font-bold">Let/Stroke Decision Helper</h2>
+      <div className="modal-box max-w-2xl p-4 sm:p-6">
+        <div className="flex justify-between items-center gap-2 mb-3 sm:mb-4">
+          <h2 className="text-lg sm:text-xl md:text-2xl font-bold">
+            Let/Stroke Decision Helper
+          </h2>
           <button
             onClick={onClose}
-            className="btn btn-ghost btn-circle btn-sm"
+            className="btn btn-ghost btn-circle btn-xs sm:btn-sm flex-shrink-0"
             aria-label="Close modal"
           >
-            <X className="w-5 h-5" />
+            <X className="w-4 h-4 sm:w-5 sm:h-5" />
           </button>
         </div>
         <LetStrokeDecision />

--- a/src/components/modals/TimersModal.tsx
+++ b/src/components/modals/TimersModal.tsx
@@ -12,18 +12,20 @@ export const TimersModal = ({ isOpen, onClose }: TimersModalProps) => {
 
   return (
     <div className="modal modal-open">
-      <div className="modal-box max-w-4xl max-h-[90vh] overflow-y-auto">
-        <div className="flex justify-between items-center mb-4">
-          <h2 className="text-2xl font-bold">Match Timers & Conduct</h2>
+      <div className="modal-box max-w-4xl max-h-[90vh] overflow-y-auto p-4 sm:p-6">
+        <div className="flex justify-between items-center gap-2 mb-3 sm:mb-4">
+          <h2 className="text-lg sm:text-xl md:text-2xl font-bold">
+            Match Timers & Conduct
+          </h2>
           <button
             onClick={onClose}
-            className="btn btn-ghost btn-circle btn-sm"
+            className="btn btn-ghost btn-circle btn-xs sm:btn-sm flex-shrink-0"
             aria-label="Close modal"
           >
-            <X className="w-5 h-5" />
+            <X className="w-4 h-4 sm:w-5 sm:h-5" />
           </button>
         </div>
-        <div className="space-y-8">
+        <div className="space-y-4 sm:space-y-6 md:space-y-8">
           <Timers />
           <ConductWarnings />
         </div>

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -22,53 +22,55 @@ function App() {
 
   return (
     <div className="min-h-full bg-gradient-to-br from-base-200 to-base-300">
-      <div className="container mx-auto px-4 py-8 sm:py-12 lg:py-16">
+      <div className="container mx-auto px-3 sm:px-4 py-6 sm:py-8 lg:py-12 max-w-6xl">
         {/* Hero Section */}
-        <div className="text-center mb-12">
-          <div className="flex flex-col items-center gap-6 mb-8">
-            <div className="relative p-6 rounded-2xl bg-base-100 shadow-2xl border border-base-300">
+        <div className="text-center mb-8 sm:mb-12">
+          <div className="flex flex-col items-center gap-4 sm:gap-6 mb-6 sm:mb-8">
+            <div className="relative p-4 sm:p-6 rounded-2xl bg-base-100 shadow-2xl border border-base-300">
               <img
                 src="/pcs_shield.png"
                 alt="PCS Shield"
-                className="w-24 h-24 sm:w-32 sm:h-32 lg:w-40 lg:h-40 object-contain"
+                className="w-20 h-20 sm:w-24 sm:h-24 md:w-32 md:h-32 lg:w-40 lg:h-40 object-contain"
               />
             </div>
-            <h1 className="text-4xl sm:text-5xl lg:text-6xl font-bold bg-gradient-to-r from-primary to-accent bg-clip-text text-transparent">
+            <h1 className="text-3xl sm:text-4xl md:text-5xl lg:text-6xl font-bold bg-gradient-to-r from-primary to-accent bg-clip-text text-transparent px-4">
               Squash Score Keeper
             </h1>
           </div>
-          <p className="text-lg sm:text-xl text-base-content/70 max-w-2xl mx-auto mb-8">
+          <p className="text-base sm:text-lg md:text-xl text-base-content/70 max-w-2xl mx-auto mb-6 sm:mb-8 px-4">
             Professional scoring system for doubles squash matches using PAR-15
             rules
           </p>
           <button
             onClick={handleStartNewMatch}
             disabled={isStarting}
-            className="btn btn-primary btn-lg gap-2 shadow-xl hover:shadow-2xl transition-all"
+            className="btn btn-primary btn-md sm:btn-lg gap-2 shadow-xl hover:shadow-2xl transition-all w-full max-w-xs sm:w-auto"
           >
             {isStarting ? (
               <>
                 <span className="loading loading-spinner loading-sm"></span>
-                Creating Match...
+                <span>Creating Match...</span>
               </>
             ) : (
               <>
-                <Play className="w-5 h-5" />
-                Start New Match
+                <Play className="w-4 h-4 sm:w-5 sm:h-5" />
+                <span>Start New Match</span>
               </>
             )}
           </button>
         </div>
 
         {/* Features Grid */}
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-6 max-w-5xl mx-auto">
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 sm:gap-6 max-w-5xl mx-auto">
           <div className="card bg-base-100 shadow-xl hover:shadow-2xl transition-all border border-base-300 hover:border-primary/50">
-            <div className="card-body items-center text-center">
-              <div className="bg-primary/10 p-5 rounded-full mb-4 border-2 border-primary/20">
-                <Users className="w-10 h-10 text-primary" />
+            <div className="card-body items-center text-center p-4 sm:p-6">
+              <div className="bg-primary/10 p-4 sm:p-5 rounded-full mb-3 sm:mb-4 border-2 border-primary/20">
+                <Users className="w-8 h-8 sm:w-10 sm:h-10 text-primary" />
               </div>
-              <h2 className="card-title text-primary">Doubles Tracking</h2>
-              <p className="text-sm text-base-content/70">
+              <h2 className="card-title text-primary text-base sm:text-lg">
+                Doubles Tracking
+              </h2>
+              <p className="text-xs sm:text-sm text-base-content/70">
                 Track all four players with automatic serve rotation and
                 hand-in/hand-out management
               </p>
@@ -76,25 +78,29 @@ function App() {
           </div>
 
           <div className="card bg-base-100 shadow-xl hover:shadow-2xl transition-all border border-base-300 hover:border-primary/50">
-            <div className="card-body items-center text-center">
-              <div className="bg-accent/10 p-5 rounded-full mb-4 border-2 border-accent/20">
-                <Target className="w-10 h-10 text-accent" />
+            <div className="card-body items-center text-center p-4 sm:p-6">
+              <div className="bg-accent/10 p-4 sm:p-5 rounded-full mb-3 sm:mb-4 border-2 border-accent/20">
+                <Target className="w-8 h-8 sm:w-10 sm:h-10 text-accent" />
               </div>
-              <h2 className="card-title text-accent">PAR-15 Scoring</h2>
-              <p className="text-sm text-base-content/70">
+              <h2 className="card-title text-accent text-base sm:text-lg">
+                PAR-15 Scoring
+              </h2>
+              <p className="text-xs sm:text-sm text-base-content/70">
                 Official PAR-15 scoring rules with automatic game and match
                 completion detection
               </p>
             </div>
           </div>
 
-          <div className="card bg-base-100 shadow-xl hover:shadow-2xl transition-all border border-base-300 hover:border-primary/50">
-            <div className="card-body items-center text-center">
-              <div className="bg-success/10 p-5 rounded-full mb-4 border-2 border-success/20">
-                <Trophy className="w-10 h-10 text-success" />
+          <div className="card bg-base-100 shadow-xl hover:shadow-2xl transition-all border border-base-300 hover:border-primary/50 sm:col-span-2 lg:col-span-1">
+            <div className="card-body items-center text-center p-4 sm:p-6">
+              <div className="bg-success/10 p-4 sm:p-5 rounded-full mb-3 sm:mb-4 border-2 border-success/20">
+                <Trophy className="w-8 h-8 sm:w-10 sm:h-10 text-success" />
               </div>
-              <h2 className="card-title text-success">Match History</h2>
-              <p className="text-sm text-base-content/70">
+              <h2 className="card-title text-success text-base sm:text-lg">
+                Match History
+              </h2>
+              <p className="text-xs sm:text-sm text-base-content/70">
                 Complete game-by-game breakdown with detailed scoring grid and
                 statistics
               </p>
@@ -103,47 +109,49 @@ function App() {
         </div>
 
         {/* Quick Start Guide */}
-        <div className="mt-12 max-w-3xl mx-auto">
+        <div className="mt-8 sm:mt-12 max-w-3xl mx-auto">
           <div className="card bg-base-100 shadow-xl border border-base-300">
-            <div className="card-body">
-              <h2 className="card-title text-2xl mb-6 text-primary">
+            <div className="card-body p-4 sm:p-6">
+              <h2 className="card-title text-xl sm:text-2xl mb-4 sm:mb-6 text-primary">
                 Quick Start
               </h2>
-              <div className="space-y-4">
-                <div className="flex gap-4 items-start p-4 bg-base-200 rounded-lg border border-base-300">
-                  <div className="w-10 h-10 rounded-full bg-primary text-primary-content flex items-center justify-center font-bold flex-shrink-0">
+              <div className="space-y-3 sm:space-y-4">
+                <div className="flex gap-3 sm:gap-4 items-start p-3 sm:p-4 bg-base-200 rounded-lg border border-base-300">
+                  <div className="w-8 h-8 sm:w-10 sm:h-10 rounded-full bg-primary text-primary-content flex items-center justify-center font-bold flex-shrink-0 text-sm sm:text-base">
                     1
                   </div>
-                  <div>
-                    <h3 className="font-bold text-lg mb-1">
+                  <div className="flex-1 min-w-0">
+                    <h3 className="font-bold text-base sm:text-lg mb-1">
                       Enter Player Names
                     </h3>
-                    <p className="text-sm text-base-content/70">
+                    <p className="text-xs sm:text-sm text-base-content/70">
                       Add all four players and assign them to right/left wall
                       positions
                     </p>
                   </div>
                 </div>
-                <div className="flex gap-4 items-start p-4 bg-base-200 rounded-lg border border-base-300">
-                  <div className="w-10 h-10 rounded-full bg-primary text-primary-content flex items-center justify-center font-bold flex-shrink-0">
+                <div className="flex gap-3 sm:gap-4 items-start p-3 sm:p-4 bg-base-200 rounded-lg border border-base-300">
+                  <div className="w-8 h-8 sm:w-10 sm:h-10 rounded-full bg-primary text-primary-content flex items-center justify-center font-bold flex-shrink-0 text-sm sm:text-base">
                     2
                   </div>
-                  <div>
-                    <h3 className="font-bold text-lg mb-1">
+                  <div className="flex-1 min-w-0">
+                    <h3 className="font-bold text-base sm:text-lg mb-1">
                       Set First Servers
                     </h3>
-                    <p className="text-sm text-base-content/70">
+                    <p className="text-xs sm:text-sm text-base-content/70">
                       Choose which player serves first for each team at hand-in
                     </p>
                   </div>
                 </div>
-                <div className="flex gap-4 items-start p-4 bg-base-200 rounded-lg border border-base-300">
-                  <div className="w-10 h-10 rounded-full bg-primary text-primary-content flex items-center justify-center font-bold flex-shrink-0">
+                <div className="flex gap-3 sm:gap-4 items-start p-3 sm:p-4 bg-base-200 rounded-lg border border-base-300">
+                  <div className="w-8 h-8 sm:w-10 sm:h-10 rounded-full bg-primary text-primary-content flex items-center justify-center font-bold flex-shrink-0 text-sm sm:text-base">
                     3
                   </div>
-                  <div>
-                    <h3 className="font-bold text-lg mb-1">Start Playing</h3>
-                    <p className="text-sm text-base-content/70">
+                  <div className="flex-1 min-w-0">
+                    <h3 className="font-bold text-base sm:text-lg mb-1">
+                      Start Playing
+                    </h3>
+                    <p className="text-xs sm:text-sm text-base-content/70">
                       Track each rally and let the app handle all scoring rules
                       automatically
                     </p>

--- a/src/routes/match.$matchId.game.$gameNumber.tsx
+++ b/src/routes/match.$matchId.game.$gameNumber.tsx
@@ -352,7 +352,7 @@ function GameRoute() {
   }, [matchActorRef, navigate])
 
   return (
-    <div className="flex flex-col lg:flex-row gap-4 p-2 sm:p-4 max-w-full mx-auto bg-gradient-to-br from-base-200 to-base-300 min-h-full">
+    <div className="flex flex-col lg:flex-row gap-3 sm:gap-4 p-2 sm:p-3 md:p-4 max-w-7xl mx-auto bg-gradient-to-br from-base-200 to-base-300 min-h-full">
       {/* Match Progress Sidebar - Desktop */}
       {matchActorRef && (
         <div className="hidden lg:block lg:w-80 flex-shrink-0">

--- a/src/routes/match.$matchId.summary.tsx
+++ b/src/routes/match.$matchId.summary.tsx
@@ -137,14 +137,14 @@ function MatchSummaryRoute() {
               <div
                 className={`stat bg-base-200 rounded-lg ${matchWinnerTeam === 'A' ? 'ring-2 ring-success' : ''}`}
               >
-                <div className="stat-title">{players.teamA}</div>
+                <div className="stat-title truncate">{players.teamA}</div>
                 <div className="stat-value text-primary">{gamesWonA}</div>
                 <div className="stat-desc">Games Won</div>
               </div>
               <div
                 className={`stat bg-base-200 rounded-lg ${matchWinnerTeam === 'B' ? 'ring-2 ring-success' : ''}`}
               >
-                <div className="stat-title">{players.teamB}</div>
+                <div className="stat-title truncate">{players.teamB}</div>
                 <div className="stat-value text-secondary">{gamesWonB}</div>
                 <div className="stat-desc">Games Won</div>
               </div>

--- a/src/utils/nameUtils.ts
+++ b/src/utils/nameUtils.ts
@@ -35,3 +35,65 @@ export const truncateName = (name: string, maxLength: number): string => {
   if (name.length <= maxLength) return name
   return `${name.substring(0, maxLength - 1)}…`
 }
+
+/**
+ * Abbreviates a full name to first initial + last name (e.g., "John Gordon" -> "J. Gordon")
+ * If no last name is provided, returns the full first name (e.g., "John" -> "John")
+ * Useful for responsive layouts where space is limited
+ */
+export const abbreviateName = (firstName: string, lastName: string): string => {
+  const firstNameTrimmed = firstName.trim()
+  const lastNameTrimmed = lastName.trim()
+
+  // If no last name, return full first name
+  if (!lastNameTrimmed) {
+    return firstNameTrimmed
+  }
+
+  // If no first name, return last name
+  if (!firstNameTrimmed) {
+    return lastNameTrimmed
+  }
+
+  // Both names present: abbreviate to initial + last name
+  const firstInitial = firstNameTrimmed.charAt(0)
+  return `${firstInitial}. ${lastNameTrimmed}`
+}
+
+/**
+ * Formats a team name with abbreviated player names for responsive display
+ * e.g., "J. Gordon & M. Smith"
+ */
+export const formatTeamNameAbbreviated = (
+  player1FirstName: string,
+  player1LastName: string,
+  player2FirstName: string,
+  player2LastName: string,
+): string => {
+  const hasNames =
+    player1FirstName || player1LastName || player2FirstName || player2LastName
+  if (!hasNames) return 'Team (Names not set)'
+
+  const player1 = abbreviateName(player1FirstName, player1LastName)
+  const player2 = abbreviateName(player2FirstName, player2LastName)
+  return `${player1} & ${player2}`
+}
+
+/**
+ * Formats a full team name
+ * e.g., "John Gordon & Mike Smith"
+ */
+export const formatTeamNameFull = (
+  player1FirstName: string,
+  player1LastName: string,
+  player2FirstName: string,
+  player2LastName: string,
+): string => {
+  const hasNames =
+    player1FirstName || player1LastName || player2FirstName || player2LastName
+  if (!hasNames) return 'Team (Names not set)'
+
+  const player1 = `${player1FirstName.trim()} ${player1LastName.trim()}`.trim()
+  const player2 = `${player2FirstName.trim()} ${player2LastName.trim()}`.trim()
+  return `${player1} & ${player2}`
+}


### PR DESCRIPTION
## Description
Fixed responsive layout issues across mobile displays from iPhone to desktop, including text overflow in match summary.

## Related Issue
Closes #9

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made
- Added text truncation to match summary team names to prevent overflow on small screens
- Improved responsive layouts throughout the app components
- Enhanced mobile navigation and UI components
- Fixed text bleeding out of containers on iPhone displays

## Testing
- [x] Tested locally
- [x] Verified in browser (if UI change)

**Tested on multiple viewport sizes:**
- iPhone (375x667)
- iPad (768x1024)
- Desktop (1440x900)

**Verified UI states:**
- Home page
- Match setup
- Game play screen
- Match summary

## Screenshots/Videos
Team names now properly truncate with ellipsis on small screens instead of bleeding out of containers.

## Checklist
- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings

## Additional Notes
The fix uses Tailwind's `truncate` utility class which applies `overflow: hidden`, `text-overflow: ellipsis`, and `white-space: nowrap` to prevent text overflow in constrained containers.